### PR TITLE
Fix subpackage imports and handle duplicate imports

### DIFF
--- a/autoimport/__init__.py
+++ b/autoimport/__init__.py
@@ -3,4 +3,4 @@
 from autoimport.main import LazyLoader, lazy
 
 __all__ = ("LazyLoader", "lazy")
-__version__ = "0.0.1"
+__version__ = "0.0.2"

--- a/autoimport/main.py
+++ b/autoimport/main.py
@@ -31,12 +31,9 @@ class LazyLoader(types.ModuleType):
         self._load_module()
         return getattr(self._module, attr)
 
-    def __dir__(self):  # For better autocompletion
-        """Returns built-in dir() result when module is not loaded to support autocompletion without triggering load."""
-        if self._module is not None:  # Only load if already loaded
-            return dir(self._module)
-        else:
-            return super().__dir__()  # Return default dir() for unloaded modules
+    def __dir__(self):
+        """Returns default dir() for unloaded modules or the module if already loaded."""
+        return dir(self._module) if self._module is not None else super().__dir__()
 
     def __repr__(self):
         """Returns a string representation of the LazyLoader module wrapper instance."""
@@ -97,7 +94,7 @@ class lazy:
                 parents = ['.'.join(parts[:i]) for i in range(1, len(parts))]
                 for parent in parents:
                     p = self._globals.get(parent, None)
-                    if p is None or (isinstance(p, LazyLoader) and p.__name__ == name):
+                    if p is None or isinstance(p, LazyLoader) or p.__name__ == name:
                         # handle subpackage imports
                         self._globals[parent] = sys.modules.get(parent, LazyLoader(parent))
 
@@ -131,7 +128,7 @@ if __name__ == "__main__":
     print(linalg.det(A))
     print(time.perf_counter() - t5)
 
-    # Direct LazyLoader() tests ------------------------
+    # Direct usage of LayzLoader class
     t6 = time.perf_counter()
     seaborn_lazy = LazyLoader("seaborn")
     print(time.perf_counter() - t6)

--- a/autoimport/main.py
+++ b/autoimport/main.py
@@ -41,10 +41,11 @@ class LazyLoader(types.ModuleType):
 
 class lazy:
     """Context manager for lazy imports."""
-    _lazy_modules = {}  # Store lazy modules here
+
     def __init__(self):
         """Initializes a context manager for lazy module imports to optimize startup time and memory usage."""
         self._original_import = builtins.__import__
+        self._lazy_modules = {}  # Store lazy modules here
         self._globals = {}
 
     def __enter__(self):
@@ -71,10 +72,10 @@ class lazy:
                 return types.SimpleNamespace(
                     **{from_item: self._lazy_modules[f"{module_name}.{from_item}"] for from_item in fromlist}
                 )
-            elif module_name in globals:
-                return globals[module_name]
             else:
                 if module_name in sys.modules:
+                    self._lazy_modules[module_name] = globals[module_name]  # avoid duplicate issue
+                elif module_name in sys.modules:
                     self._lazy_modules[module_name] =  sys.modules[module_name]  # module already loaded in session
                 elif module_name not in self._lazy_modules:
                     self._lazy_modules[module_name] = LazyLoader(module_name)

--- a/autoimport/main.py
+++ b/autoimport/main.py
@@ -46,7 +46,7 @@ class lazy:
         """Initializes a context manager for lazy module imports to optimize startup time and memory usage."""
         self._original_import = builtins.__import__
         self._lazy_modules = {}  # Store lazy modules here
-        self._globals = None
+        self._globals = {}
 
     def __enter__(self):
         """Enters a context where imports are lazy-loaded, replacing Python's default import mechanism."""

--- a/autoimport/main.py
+++ b/autoimport/main.py
@@ -94,7 +94,7 @@ class lazy:
                 parents = ['.'.join(parts[:i]) for i in range(1, len(parts))]
                 for parent in parents:
                     p = self._globals.get(parent, None)
-                    if p is None or isinstance(p, LazyLoader) or p.__name__ == name:
+                    if p is None or p.__name__ == name:
                         # handle subpackage imports
                         self._globals[parent] = sys.modules.get(parent, LazyLoader(parent))
 

--- a/autoimport/main.py
+++ b/autoimport/main.py
@@ -41,10 +41,11 @@ class LazyLoader(types.ModuleType):
 
 class lazy:
     """Context manager for lazy imports."""
-    _lazy_modules = {}
+
     def __init__(self):
         """Initializes a context manager for lazy module imports to optimize startup time and memory usage."""
         self._original_import = builtins.__import__
+        self._lazy_modules = {}  # Store lazy modules here
         self._globals = None
 
     def __enter__(self):

--- a/autoimport/main.py
+++ b/autoimport/main.py
@@ -41,11 +41,10 @@ class LazyLoader(types.ModuleType):
 
 class lazy:
     """Context manager for lazy imports."""
-
+    _lazy_modules = {}  # Store lazy modules here
     def __init__(self):
         """Initializes a context manager for lazy module imports to optimize startup time and memory usage."""
         self._original_import = builtins.__import__
-        self._lazy_modules = {}  # Store lazy modules here
         self._globals = {}
 
     def __enter__(self):

--- a/autoimport/main.py
+++ b/autoimport/main.py
@@ -89,7 +89,7 @@ class lazy:
         # Now that builtins is restored, we can load any modules that need loading
         for name, lazy_module in self._lazy_modules.items():
             if "." in name:
-                parts = s.split('.')
+                parts = name.split('.')
                 parents = ['.'.join(parts[:i]) for i in range(1, len(parts))]
                 for parent in parents:
                     p = self._globals.get(parent, None)

--- a/autoimport/main.py
+++ b/autoimport/main.py
@@ -3,7 +3,6 @@
 import builtins
 import importlib
 import sys
-import time
 import types
 
 
@@ -99,7 +98,9 @@ class lazy:
                         self._globals[parent] = sys.modules.get(parent, LazyLoader(parent))
 
 if __name__ == "__main__":
-    # Context manager tests -----------------------------
+    import time
+
+    # Context manager
     with lazy():
         t0 = time.perf_counter()
         import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ dependencies = []
 [project.optional-dependencies]
 dev = [
     "numpy",  # for tests
-    "torch",
 ]
 
 [project.urls]  # Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ dependencies = []
 # Optional dependencies ------------------------------------------------------------------------------------------------
 [project.optional-dependencies]
 dev = [
-    "numpy",  # for import tests
+    "numpy",  # for tests
+    "torch",
 ]
 
 [project.urls]  # Optional

--- a/tests/test_autoimport.py
+++ b/tests/test_autoimport.py
@@ -30,19 +30,12 @@ class TestLazyImports(unittest.TestCase):
         result = json.dumps({"test": 123})
         self.assertIsInstance(result, str)
 
-    def test_submodule_imports_numpy(self):
+    def test_submodule_imports(self):
         """Test numpy module imports and functionality."""
         with lazy():
             import numpy.random
         random_number = numpy.random.rand()
         self.assertLess(random_number, 1.0)
-
-    def test_submodule_imports_torch(self):
-        """Test torch module imports and functionality."""
-        with lazy():
-            import torch.nn
-        module = torch.nn.Identity()
-        self.assertIsInstance(module, torch.nn.Identity)
     
     def test_direct_lazyloader(self):
         """Test direct LazyLoader instantiation."""

--- a/tests/test_autoimport.py
+++ b/tests/test_autoimport.py
@@ -22,13 +22,20 @@ class TestLazyImports(unittest.TestCase):
         result = json.dumps({"test": 123})
         self.assertIsInstance(result, str)
 
-    def test_submodule_imports(self):
-        """Test nested module imports and functionality."""
+    def test_submodule_imports_numpy(self):
+        """Test numpy module imports and functionality."""
         with lazy():
             import numpy.random
         random_number = numpy.random.rand()
         self.assertLess(random_number, 1.0)
 
+    def test_submodule_imports_torch(self):
+        """Test torch module imports and functionality."""
+        with lazy():
+            import torch.nn
+        module = torch.nn.Identity()
+        self.assertIsInstance(module, torch.nn.Identity)
+    
     def test_direct_lazyloader(self):
         """Test direct LazyLoader instantiation."""
         base64_lazy = LazyLoader("base64")


### PR DESCRIPTION
Subpackage imports should work now. Also added handling if packages are already imported.

```python
from autoimport import lazy

with lazy():
    import torch.nn

torch.nn.Identity()
```

```python
from autoimport import lazy
import torch.nn  # already imported 

with lazy():
    import torch.nn  # will return imported module instead of LazyLoader
```

```python
from autoimport import lazy

with lazy():
    import torch.nn

torch.nn.Identity()

with lazy():
    import torch.nn  # no errors with duplicates 

torch.nn.Identity()
```
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->
