### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ["3.8", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows/ci.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in CI from `actions/checkout@v4` to `actions/checkout@v6`.

### 📊 Key Changes
- Upgraded the CI workflow in `.github/workflows/ci.yml`
- Replaced `actions/checkout@v4` with `actions/checkout@v6`
- No application code or package functionality was changed; this is a CI maintenance update only 🛠️

### 🎯 Purpose & Impact
- Keeps the repository’s GitHub Actions workflow aligned with newer action versions ✅
- May improve CI reliability, compatibility, and security through upstream updates 🔒
- Has no direct effect on end users or library behavior, but helps maintain a healthier development pipeline 🚀