### PR TITLE
Bump actions/setup-python from v5 to v6 in /.github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Bump actions/setup-python from v5 to v6 in /.github/workflows/ci.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use `actions/setup-python@v6` instead of `@v5`, keeping the repository’s automation up to date.

### 📊 Key Changes
- Upgraded the CI workflow in `.github/workflows/ci.yml`
- Replaced `actions/setup-python@v5` with `actions/setup-python@v6`
- No application code or package functionality was changed

### 🎯 Purpose & Impact
- 🚀 Keeps the project aligned with the latest GitHub Actions tooling
- 🛡️ May improve CI reliability, compatibility, and security through the newer action version
- 👩‍💻 Has no direct impact on end users, but helps maintainers by keeping automated testing and checks current
- ✅ Reduces the risk of future issues from using an older CI dependency