### PR TITLE
Bump astral-sh/setup-uv from v5 to v8 in /.github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Bump astral-sh/setup-uv from v5 to v8 in /.github/workflows/ci.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use a newer version of `astral-sh/setup-uv`, improving dependency setup in automated testing.

### 📊 Key Changes
- Upgraded the CI workflow action from `astral-sh/setup-uv@v5` to `astral-sh/setup-uv@v8` in `.github/workflows/ci.yml`.
- No application code or user-facing features were changed; this is a maintenance update to the repository’s automation.

### 🎯 Purpose & Impact
- 🚀 Keeps the CI pipeline current with the latest `setup-uv` action improvements and fixes.
- 🛠️ May improve reliability, compatibility, and stability of dependency installation during automated tests.
- 📦 Helps reduce risk from using older GitHub Action versions and supports ongoing repository maintenance.
- 👥 Minimal direct impact on end users, but contributors may benefit from smoother and more dependable CI runs.