### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows/publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       current_tag: ${{ steps.check_pypi.outputs.current_tag }}
       previous_tag: ${{ steps.check_pypi.outputs.previous_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows/publish.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in the publish workflow from `actions/checkout@v4` to `actions/checkout@v6` to keep CI/CD dependencies current.

### 📊 Key Changes
- 🛠️ Updated `.github/workflows/publish.yml`
- ⬆️ Replaced `actions/checkout@v4` with `actions/checkout@v6`
- 🚀 Change applies to the repository publishing workflow used during release automation

### 🎯 Purpose & Impact
- ✅ Keeps the GitHub Actions workflow aligned with newer supported action versions
- 🔒 May improve security, compatibility, and long-term maintenance of the release pipeline
- 🤖 Helps reduce risk of using outdated CI dependencies in automated publishing
- 👥 No direct user-facing feature changes, but it supports a more reliable package release process