### PR TITLE
Bump actions/upload-artifact from v4 to v7 in /.github/workflows/publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv pip install --system --no-cache build
       - run: python -m build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Bump actions/upload-artifact from v4 to v7 in /.github/workflows/publish.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the package publishing workflow by upgrading the GitHub artifact upload action from `actions/upload-artifact@v4` to `actions/upload-artifact@v7`.

### 📊 Key Changes
- Updated `.github/workflows/publish.yml` in the release pipeline.
- Replaced `actions/upload-artifact@v4` with `actions/upload-artifact@v7`.
- No changes were made to application code, package contents, or user-facing features.

### 🎯 Purpose & Impact
- Improves the reliability and maintainability of the GitHub Actions publishing workflow 🚀
- Keeps CI/CD dependencies more up to date and aligned with newer GitHub Actions versions 🔄
- Helps reduce the risk of future compatibility or deprecation issues in the release process 🛡️
- Minimal impact for end users, but beneficial for maintainers by making package publishing more future-proof ⚙️