### PR TITLE
Bump actions/download-artifact from v4 to v8 in /.github/workflows/publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
     permissions:
       id-token: write # for PyPI trusted publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Bump actions/download-artifact from v4 to v8 in /.github/workflows/publish.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions artifact download step in the publish workflow from `actions/download-artifact@v4` to `@v8` to keep the release pipeline current and supported.

### 📊 Key Changes
- Upgraded the `actions/download-artifact` GitHub Action in `.github/workflows/publish.yml`
- Changed the publish job dependency from version `v4` to `v8`
- No application code or package behavior was modified; this is a CI/CD workflow maintenance update 🛠️

### 🎯 Purpose & Impact
- Improves the reliability and long-term maintainability of the release pipeline 🚀
- Keeps the repository aligned with newer GitHub Actions versions and ecosystem updates
- Helps reduce risk from using older workflow dependencies, including compatibility or support issues 🔒
- Has no direct impact on end users of `ultralytics/autoimport`, but helps ensure smoother package publishing behind the scenes 📦