### PR TITLE
Bump actions/checkout from v5 to v6 in /.github/workflows/publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,7 +99,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"


### PR DESCRIPTION
Bump actions/checkout from v5 to v6 in /.github/workflows/publish.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in the publish workflow from `actions/checkout@v5` to `actions/checkout@v6`.

### 📊 Key Changes
- Upgraded `.github/workflows/publish.yml` to use `actions/checkout@v6` instead of `actions/checkout@v5`.
- The change applies specifically to the **publish** GitHub Actions workflow.
- No application code or package functionality was modified—this is a CI/CD maintenance update only. 🛠️

### 🎯 Purpose & Impact
- Improves workflow maintenance by keeping GitHub Actions dependencies up to date. 📦
- Helps ensure better compatibility with the latest GitHub Actions ecosystem and future platform changes. ✅
- Reduces the risk of using outdated automation components in the release pipeline. 🔒
- End users should not see any direct behavior change in the package itself, but maintainers may benefit from a more reliable publishing process. 🚀