### PR TITLE
Bump astral-sh/setup-uv from v6 to v8 in /.github/workflows/publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
       - run: |
           uv venv sbom-env
           uv pip install -e .


### PR DESCRIPTION
Bump astral-sh/setup-uv from v6 to v8 in /.github/workflows/publish.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub publishing workflow to use a newer version of the `setup-uv` action, improving dependency setup in the release pipeline.

### 📊 Key Changes
- Upgraded the GitHub Action `astral-sh/setup-uv` in `.github/workflows/publish.yml`
- Changed the action version from `v6` to `v8`
- No application code or package logic was modified; this is a CI/CD workflow maintenance update only 🛠️

### 🎯 Purpose & Impact
- Helps keep the publishing pipeline aligned with newer GitHub Action releases 🚀
- May improve reliability, compatibility, and future support for environment setup during publish jobs
- Reduces the risk of using outdated CI tooling over time 🔒
- Low impact for end users, but beneficial for maintainers by making releases smoother and easier to maintain 🙂