### PR TITLE
Bump slackapi/slack-github-action from v2.0.0 to v3.0.1 in /.github/workflows/publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,7 +135,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v2.0.0 to v3.0.1 in /.github/workflows/publish.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the Slack GitHub Action used in the release workflow, moving it from `v2.0.0` to `v3.0.1` for success notifications after publishing.

### 📊 Key Changes
- ⬆️ Upgraded the Slack notification step in `.github/workflows/publish.yml`
- 🔔 Replaced `slackapi/slack-github-action@v2.0.0` with `slackapi/slack-github-action@v3.0.1`
- 🛠️ Kept the existing notification behavior the same: Slack alerts still trigger only when publishing succeeds on a push event

### 🎯 Purpose & Impact
- ✅ Improves workflow maintainability by using a newer version of the Slack GitHub Action
- 🔒 May provide bug fixes, compatibility improvements, and security updates from the upstream action
- 📦 Helps keep the release pipeline modern and reliable without changing how users interact with the project
- 👀 Minimal user-facing impact, but maintainers benefit from a more up-to-date CI/CD notification setup