### PR TITLE
Bump astral-sh/setup-uv to v8 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
       - run: |
           uv venv sbom-env
           uv pip install -e .


### PR DESCRIPTION
Bump astral-sh/setup-uv to v8 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR modernizes the GitHub Actions setup by upgrading all `astral-sh/setup-uv` steps to `v8`, improving CI and publishing workflow consistency.

### 📊 Key Changes
- ⬆️ Updated `.github/workflows/ci.yml` from `astral-sh/setup-uv@v5` to `@v8`
- ⬆️ Updated multiple steps in `.github/workflows/publish.yml` from older `setup-uv` versions (`@v5` and `@v6`) to `@v8`
- 🧹 Standardized all workflow files to use the same, latest `setup-uv` action version
- ⚙️ Changes affect:
  - CI dependency installation
  - Package build and publish pipeline
  - SBOM-related environment setup

### 🎯 Purpose & Impact
- ✅ Keeps GitHub Actions up to date with the latest `uv` setup action version
- 🔒 Likely improves reliability, compatibility, and security of automation workflows
- 🛠️ Reduces maintenance burden by removing mixed action versions across workflows
- 🚀 Helps ensure CI, package publishing, and build-related jobs run more consistently for contributors and maintainers
- 👀 No user-facing package functionality changes are introduced; this is an infrastructure and developer-experience improvement