### PR TITLE
Bump actions/setup-python to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       previous_tag: ${{ steps.check_pypi.outputs.previous_tag }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v5
@@ -64,7 +64,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v5
@@ -100,7 +100,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
Bump actions/setup-python to v6 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions Python setup step from `actions/setup-python@v5` to `@v6` in the package publishing workflow to keep CI/CD tooling current.

### 📊 Key Changes
- Upgraded `actions/setup-python` from `v5` to `v6` in `.github/workflows/publish.yml` ✅
- Applied the update across all relevant workflow jobs in the publish pipeline 🔄
- Left the rest of the publishing logic unchanged, making this a focused maintenance update 🧰

### 🎯 Purpose & Impact
- Improves workflow maintainability by aligning the repository with the latest GitHub Action version 📦
- Helps reduce risk from using older action versions, including potential compatibility or support issues 🛡️
- Keeps the release and publishing pipeline more future-ready with minimal behavioral change for users 🚀
- Likely has little to no direct impact on end users, but benefits maintainers through a more up-to-date CI setup 👨‍💻