### PR TITLE
Bump actions/checkout to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
@@ -123,7 +123,7 @@ jobs:
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Extract PR Details
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump actions/checkout to v6 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in the publish workflow from `actions/checkout@v4` to `actions/checkout@v6`.

### 📊 Key Changes
- Upgraded the `actions/checkout` action in `.github/workflows/publish.yml`
- Changed the publish job dependency from:
  - `actions/checkout@v4` ➝ `actions/checkout@v6`
- No application code or package behavior was changed; this is a CI/CD workflow maintenance update 🛠️

### 🎯 Purpose & Impact
- Improves the repository’s GitHub Actions workflow by using a newer version of the checkout action 🚀
- Helps keep the publishing pipeline current with the latest GitHub Actions ecosystem updates
- May provide better reliability, compatibility, and long-term support for automated releases ✅
- Low user-facing impact: this mainly benefits maintainers and release automation rather than changing runtime functionality for end users 👥