### PR TITLE
Bump slackapi/slack-github-action to v3.0.1 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,7 @@ jobs:
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
       - name: Notify Failure
         if: needs.publish.result != 'success'
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action to v3.0.1 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR updates the Slack GitHub Action used for publish failure notifications in `autoimport`, moving it from `v2.0.0` to `v3.0.1`.

### 📊 Key Changes
- Upgraded the `slackapi/slack-github-action` version in `.github/workflows/publish.yml`
- The change only affects the **failure notification** step in the publish workflow
- Previous version: `v2.0.0`
- New version: `v3.0.1`

### 🎯 Purpose & Impact
- Improves the reliability and maintainability of Slack alerts during failed package publish runs 🚨
- Keeps the GitHub Actions workflow more up to date with the latest supported action version 🔄
- Helps repository maintainers get failure notifications through a newer dependency with potential bug fixes and compatibility improvements ✅
- Low-risk change: it does not affect package publishing itself, only how failed publish events are reported 📦