### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in the publish workflow from `actions/checkout@v4` to `actions/checkout@v6`.

### 📊 Key Changes
- Upgraded the `actions/checkout` GitHub Action in `.github/workflows/publish.yml`
- Changed the workflow dependency from `actions/checkout@v4` to `actions/checkout@v6`
- No application code or package behavior was modified—this is a CI/CD maintenance update only 🛠️

### 🎯 Purpose & Impact
- Improves workflow maintainability by keeping the publishing pipeline aligned with newer GitHub Actions versions ✅
- May provide better compatibility, security, and long-term support in GitHub-hosted automation environments 🔐
- Has little to no direct impact on end users, but helps keep release publishing more reliable for maintainers 🚀