### PR TITLE
Set workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@
 
 name: Publish to PyPI
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- add explicit read-only permissions to CI
- add workflow-level read permissions for publishing jobs that do not define their own scopes

## CodeQL alerts
Addresses:
- https://github.com/ultralytics/autoimport/security/code-scanning/1
- https://github.com/ultralytics/autoimport/security/code-scanning/2

## Validation
- Parsed workflow YAML with `yaml.safe_load()`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR tightens GitHub Actions security by adding explicit minimal permissions to the CI and PyPI publishing workflows.

### 📊 Key Changes
- Added `permissions: contents: read` to the [CI workflow](https://github.com/ultralytics/autoimport/blob/main/.github/workflows/ci.yml) ✅
- Added `permissions: contents: read` and `pull-requests: read` to the [publish workflow](https://github.com/ultralytics/autoimport/blob/main/.github/workflows/publish.yml) 📦
- Updated both workflows to follow a more restrictive, least-privilege permission model 🔒

### 🎯 Purpose & Impact
- Improves GitHub Actions security by ensuring workflows only get the access they actually need 🛡️
- Reduces risk from overly broad default token permissions in automation pipelines ⚠️
- Helps make CI and package publishing safer and more aligned with GitHub best practices 👍
- Should have little to no effect on normal users, but increases trust and maintainability for contributors and maintainers 🚀