### PR TITLE
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,7 +139,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -147,7 +147,7 @@ jobs:
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
       - name: Notify Failure
         if: needs.publish.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR updates the GitHub Actions Slack notification step to use a newer patch version of the Slack GitHub Action in the `ultralytics/autoimport` publish workflow.

### 📊 Key Changes
- Upgraded `slackapi/slack-github-action` from `v3.0.2` to `v3.0.3` in `.github/workflows/publish.yml`
- Applied the update to both:
  - ✅ the **Notify Success** step
  - ❌ the **Notify Failure** step
- No changes were made to the notification message content or overall workflow logic

### 🎯 Purpose & Impact
- Improves workflow maintenance by keeping a third-party GitHub Action up to date 🔄
- May include small bug fixes, compatibility updates, or reliability improvements from the Slack action maintainers 🛠️
- Helps reduce risk in CI/CD notifications without changing how releases are published or how alerts appear to the team 📦
- Low-impact change for users, but useful for keeping release automation stable and current 👍