### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: ultralytics/actions/setup-uv@main
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v5
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v5
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v6
+      - uses: ultralytics/actions/setup-uv@main
       - run: |
           uv venv sbom-env
           uv pip install -e .


### PR DESCRIPTION
## Summary
- replace all 4 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 4 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 Replaced the external `setup-uv` GitHub Action with Ultralytics’ centralized version across CI and publishing workflows.

### 📊 Key Changes
- Updated `.github/workflows/ci.yml` to use `ultralytics/actions/setup-uv@main`.
- Updated all `setup-uv` steps in `.github/workflows/publish.yml`.
- Replaced both `astral-sh/setup-uv@v5` and `@v6` references with the shared Ultralytics action.

### 🎯 Purpose & Impact
- ✅ Standardizes Python package and `uv` setup across Ultralytics repositories.
- 🛠️ Simplifies centralized maintenance and future workflow updates.
- 🚀 Keeps CI, package building, publishing, and SBOM generation workflows functionally consistent.
- ⚠️ Workflow behavior now depends on the shared action’s `main` branch, so changes there may affect this repository.