### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       previous_tag: ${{ steps.check_pypi.outputs.previous_tag }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main
@@ -68,7 +68,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main
@@ -104,7 +104,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated GitHub Actions workflows to use `actions/setup-python@v7` for CI and package publishing. ⚙️

### 📊 Key Changes

- Replaced `actions/setup-python@v6` with `actions/setup-python@v7` in:
  - Continuous integration workflows.
  - Package publishing and release jobs.
- Kept the existing Python version configuration and workflow structure unchanged.

### 🎯 Purpose & Impact

- ✅ Keeps the repository aligned with the latest supported Python setup action.
- 🔒 Improves workflow maintainability and may provide updated compatibility, performance, and security improvements.
- 🚀 Applies the upgrade consistently across testing and publishing pipelines without changing application behavior.