### PR TITLE
Queue publish runs and retry PyPI upload failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         description: Publish to PyPI
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   check:
     if: github.repository == 'ultralytics/autoimport' && github.actor == 'glenn-jocher'
@@ -95,6 +99,20 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+        id: publish
+        continue-on-error: true
+        with:
+          skip-existing: true # tolerate recovery re-runs after partial failures
+      - name: Clean partial attestations # leftover *.publish.attestation files make the retry fail pre-existence checks
+        if: steps.publish.outcome == 'failure'
+        run: |
+          rm -f dist/*.publish.attestation
+          sleep 30
+      - name: Retry publish # transient sigstore/Rekor or PyPI network failures
+        if: steps.publish.outcome == 'failure'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   sbom:
     needs: [check, build, publish]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   check:


### PR DESCRIPTION
## Summary

- Serialize publish workflows with `queue: max`, preserving up to 100 pending releases.
- Retry `pypa/gh-action-pypi-publish` once after transient Sigstore/Rekor or PyPI failures.
- Remove partial publish attestations and wait briefly before retrying; retain `skip-existing` for partial-upload recovery.

This applies the resilience fix from [ultralytics/ultralytics#25331](https://github.com/ultralytics/ultralytics/pull/25331) consistently across active Ultralytics PyPI publishers.

Deleted: nothing — GitHub owns workflow scheduling, and the external PyPI action exposes no retry input while retaining partial attestation files after failure.

## Validation

- `git diff --check`
- GitHub's documented `concurrency.queue: max` syntax; local actionlint 1.7.12 predates this property

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves PyPI publishing reliability by preventing overlapping releases and automatically retrying transient failures. 🚀

### 📊 Key Changes

- Added GitHub Actions concurrency control to queue publishing workflows and avoid simultaneous releases.
- Enabled `skip-existing` when publishing packages, allowing safe recovery from partially completed releases.
- Added automatic cleanup of leftover `.publish.attestation` files after a failed publish attempt.
- Added a 30-second delay before retrying publication to accommodate transient Sigstore, Rekor, or PyPI network issues.
- Configured the publish job to retry once when the initial upload fails.

### 🎯 Purpose & Impact

- Makes package releases more resilient to temporary infrastructure or network failures. 🔄
- Prevents duplicate-package errors during recovery runs.
- Reduces manual intervention when publishing to PyPI fails partway through.
- Ensures downstream jobs, such as SBOM generation, receive a more consistently completed release process.